### PR TITLE
Negotiated licensing terms with kobil, the author of the multicore project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2024, Authors: github.com/bnister, github.com/tzubertowski, source multicore contributors: https://github.com/madcock/sf2000_multicore/graphs/contributors
+Copyright (c) 2024, Authors: gitlab.com/kobily, github.com/bnister, github.com/tzubertowski, source multicore contributors: https://github.com/madcock/sf2000_multicore/graphs/contributors
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
And while he said
> i dont understand that whole complex world of open source licenses...
> in general i think i have no problem of ppl using my code...but i do want the proper acknowledgement with maybe also a link back to my repo 

of the ISC terms yet again, he has no objections over
```
Copyright (c) 2024, Authors: gitlab.com/kobily, github.com/bnister, github.com/tzubertowski, source multicore contributors: https://github.com/madcock/sf2000_multicore/graphs/contributors
[...] granted, provided that the above copyright notice and this permission notice appear in all copies
```
>>  so noone can strip the link. I guess this should be ok with you

> it is better i guess

His main concerns grow over people misrepresenting his authorship based on the GitHub cloned repo

> but frankly i don;t think ppl know that multicore is essentially my (and yours) project

> but come to think about it...it is weird that his cloned repo is considered the official multicore repo
> i guess his github has much higher visibility the my gitlab 

Thus a link to where his contributions were first posted must be first in the line of authorship for a valid license.